### PR TITLE
Mejoras en renderizado y escritura de archivos

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,9 @@ def confirm_overwrite(file_path, batch_mode=None):
 
 def write_file(file_path, content, batch_mode=None):
     """Escribe un archivo solo si se permite la sobreescritura."""
+    if file_path.endswith('.md') and not content.strip():
+        logging.debug(f"Contenido vacío. No se crea {file_path}")
+        return
     if confirm_overwrite(file_path, batch_mode):
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(content)
@@ -228,7 +231,15 @@ def render_entity(entity, template_name):
         template_path = os.path.join(TEMPLATE_DIR, template_name)
         with open(template_path, 'r', encoding='utf-8') as f:
             template_content = f.read()
-        return render_template(template_content, entity)
+        if not template_content.strip():
+            logging.debug(f"Plantilla vacía: {template_path}")
+            return ""
+        rendered = render_template(template_content, entity)
+        if not rendered.strip():
+            logging.debug(
+                f"Renderizado vacío para {entity.get('id', 'unknown')} con {template_name}"
+            )
+        return rendered
     except Exception as e:
         logging.error(f"Error al renderizar {entity.get('id', 'unknown')} con {template_name}: {e}")
         raise


### PR DESCRIPTION
## Summary
- evitar la creación de archivos Markdown vacíos
- registrar advertencias cuando la plantilla o el render resultan vacíos

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685279dcae4883218e69568153833501